### PR TITLE
🐛 fix(SemanticSegmentation): save no finlyList and open class select

### DIFF
--- a/src/components/PPCreator/index.tsx
+++ b/src/components/PPCreator/index.tsx
@@ -6,7 +6,7 @@ import Title from 'antd/lib/typography/Title';
 import { history } from 'umi';
 import styles from './index.less';
 import serviceUtils from '@/services/serviceUtils';
-import { createInfo, camel2snake, IntlInit } from '@/services/utils';
+import { createInfo, camel2snake, IntlInit, sampleApi, snake2camel } from '@/services/utils';
 import { ProjectUtils } from '@/services/utils';
 import { IntlInitJsx } from '@/components/PPIntl';
 import type { ImportOption } from '@/services/web';
@@ -267,7 +267,7 @@ const PPCreator: React.FC<PPCreatorProps> = (props) => {
               </Form.Item>
               {renderImportOptions()}
 
-              {/* <Form.Item
+              <Form.Item
                 name="labelFormat"
                 label={
                   <p
@@ -334,7 +334,7 @@ const PPCreator: React.FC<PPCreatorProps> = (props) => {
                     </Radio>
                   ))}
                 </Radio.Group>
-              </Form.Item> */}
+              </Form.Item>
 
               {/* <Form.Item
                 name="segMaskType"

--- a/src/pages/SemanticSegmentation/index.tsx
+++ b/src/pages/SemanticSegmentation/index.tsx
@@ -237,6 +237,7 @@ const Page: React.FC = () => {
     onMouseUp: () => {
       if (interactorData.active) return;
       annHistory.record({ annos: annotation.all, currAnno: annotation.curr });
+      savefinlyList();
     },
     frontendIdOps: { frontendId: frontendId, setFrontendId: setFrontendId },
     model: model,


### PR DESCRIPTION
## fix
* 修复 #1 遗漏的矩形框问题
* 暂时打开 `导入标注格式` 选择功能（不保证能用，至少还需要补充i18n）


<img width="649" alt="截屏2024-06-21 下午8 57 43" src="https://github.com/PFCCLab/PaddleLabel-Frontend/assets/66515297/6791906f-d5b2-4b55-a3aa-8ccb086e45b3">


cc: @Liyulingyue 
